### PR TITLE
Docs: Complete steering documents with work CLI project details

### DIFF
--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,19 +1,38 @@
 # Product Overview
 
 ## Product Purpose
-[Describe what your product does and why it exists]
+The work CLI is a unified, stateless command-line tool that enables developers and teams to manage work items across multiple project management backends without being locked into a single tool. It provides a consistent interface and mental model for task management whether using Jira, GitHub Issues, Linear, Azure DevOps, or local filesystem storage.
 
 ## Target Users
-[Who is your primary audience? What are their needs?]
+- **Developers and Engineering Teams**: Who work across multiple projects using different project management tools
+- **DevOps Engineers**: Who need to integrate task management into CI/CD workflows and automation
+- **Technical Project Managers**: Who need unified visibility across different project management systems
+- **Freelancers and Consultants**: Who work with clients using various project management tools
 
 ## Key Features
-[List the main features and capabilities of your product]
+- **Multi-Backend Support**: Unified interface for Jira, GitHub, Linear, Azure DevOps, and local filesystem
+- **Context-Based Scoping**: Explicit backend selection with isolated credentials and project boundaries
+- **Stateless Execution**: No daemon, no caching, predictable command-by-command execution
+- **Graph-Based Relations**: Explicit work item relationships (parent/child, blocks, duplicates, etc.)
+- **Offline-First Capability**: Full functionality via local filesystem backend
+- **Scriptable Interface**: Consistent commands suitable for automation and CI/CD integration
 
 ## Business Objectives
-[What are the main goals and success metrics?]
+- **Developer Productivity**: Reduce context switching between different project management tools
+- **Workflow Standardization**: Provide consistent task management patterns across teams and projects
+- **Tool Independence**: Prevent vendor lock-in while maintaining full feature access
+- **Automation Enablement**: Support scriptable workflows and CI/CD integration
 
 ## User Journey
-[How do users interact with your product? What's the typical workflow?]
+1. **Context Setup**: Configure contexts for different projects/backends (`work context add`)
+2. **Work Item Management**: Create, start, close, and manage work items with consistent commands
+3. **Cross-Tool Workflows**: Move work items between systems, maintain relations across backends
+4. **Query and Reporting**: Use consistent query syntax to find and filter work items
+5. **Integration**: Incorporate into existing development workflows and automation
 
 ## Success Criteria
-[How do you measure if the product is successful?]
+- **Command Response Time**: < 2s for list operations with up to 1,000 items
+- **CLI Startup Time**: < 500ms for immediate productivity
+- **Cross-Backend Consistency**: Same mental model and commands work across all supported backends
+- **Developer Adoption**: Measurable reduction in time spent switching between project management tools
+- **Workflow Integration**: Successful incorporation into CI/CD pipelines and development automation

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,25 +1,81 @@
 # Project Structure
 
 ## Directory Layout
-[Describe your project's folder structure and organization]
+```
+work-cli/
+├── src/
+│   ├── cli/           # Command parsing and CLI interface
+│   ├── core/          # Core engine and graph logic
+│   ├── adapters/      # Adapter implementations
+│   │   ├── local-fs/  # Local filesystem adapter
+│   │   ├── jira/      # Jira adapter
+│   │   ├── github/    # GitHub adapter
+│   │   ├── linear/    # Linear adapter
+│   │   └── ado/       # Azure DevOps adapter
+│   ├── types/         # TypeScript type definitions
+│   └── utils/         # Shared utilities
+├── tests/
+│   ├── unit/          # Unit tests (70%)
+│   ├── integration/   # Integration tests (20%)
+│   └── e2e/           # End-to-end tests (10%)
+├── docs/              # Documentation
+├── examples/          # Usage examples and demos
+├── scripts/           # Build and development scripts
+├── .kiro/             # Kiro CLI configuration
+├── Makefile           # Unified development commands
+└── package.json       # Node.js project configuration
+```
 
 ## File Naming Conventions
-[How files and directories should be named]
+- **TypeScript files**: camelCase with `.ts` extension
+- **Test files**: `*.test.ts` or `*.spec.ts`
+- **Configuration files**: kebab-case (e.g., `eslint.config.js`)
+- **Documentation**: kebab-case with `.md` extension
+- **Adapters**: Directory per backend with `index.ts` entry point
 
 ## Module Organization
-[How code is organized into modules, packages, or components]
+- **CLI Layer**: Command parsing, validation, and user interface
+- **Core Engine**: Context resolution, query planning, graph operations
+- **Adapter Layer**: Backend-specific implementations with uniform interface
+- **Types**: Shared TypeScript interfaces and type definitions
+- **Utils**: Cross-cutting concerns and helper functions
 
 ## Configuration Files
-[Location and purpose of config files]
+- **package.json**: Node.js dependencies and scripts
+- **tsconfig.json**: TypeScript compiler configuration
+- **jest.config.js**: Testing framework configuration
+- **eslint.config.js**: Code linting rules
+- **.prettierrc**: Code formatting configuration
+- **Makefile**: Development workflow commands
 
 ## Documentation Structure
-[Where and how documentation is organized]
+- **README.md**: Project overview and quick start
+- **docs/**: Comprehensive documentation
+  - **README.md**: Documentation index and overview
+  - **work-cli-spec.md**: Complete CLI specification and command reference
+  - **work-adapter-architecture.md**: Multi-backend support via adapter pattern
+  - **work-graph-ontology-and-runtime.md**: Internal graph model and stateless execution
+  - **work-local-fs-execution-flow.md**: Detailed execution flow for local filesystem backend
+  - **work-c4-architecture.md**: C4 architecture diagrams in PlantUML format
+  - **work-user-journey-context-and-query.md**: Concrete user journey demonstrating context and querying
+  - **work-nonfunctional-requirements.md**: Quality attributes and performance requirements
+  - **work-cli-tech-selection.md**: CLI technology selection and rationale
+  - **work-poc.md**: Proof of concept implementation plan
+- **examples/**: Working code samples and tutorials
 
 ## Asset Organization
-[How images, styles, and other assets are structured]
+- **scripts/**: Build, development, and deployment scripts
+- **examples/**: Sample configurations and usage patterns
+- **docs/**: All documentation and diagrams
 
 ## Build Artifacts
-[Where compiled/generated files are placed]
+- **dist/**: Compiled TypeScript output
+- **coverage/**: Test coverage reports
+- **node_modules/**: npm dependencies (gitignored)
+- ***.log**: Log files (gitignored)
 
 ## Environment-Specific Files
-[How different environments (dev, staging, prod) are handled]
+- **.env.example**: Template for environment variables
+- **jest.config.js**: Test environment configuration
+- **.github/workflows/**: CI/CD pipeline definitions
+- **Makefile**: Cross-platform development commands

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,25 +1,58 @@
 # Technical Architecture
 
 ## Technology Stack
-[List your main technologies, frameworks, and tools]
+- **Primary Language**: TypeScript/Node.js
+- **CLI Framework**: oclif (TypeScript-based, widely adopted for serious CLIs)
+- **Testing**: Jest with comprehensive test pyramid (70% unit, 20% integration, 10% e2e)
+- **Build System**: TypeScript compiler with bundling
+- **Package Management**: npm/yarn with lockfiles
+- **Code Quality**: ESLint + Prettier with pre-commit hooks
+- **CI/CD**: GitHub Actions for automated testing and releases
 
 ## Architecture Overview
-[High-level system architecture and components]
+- **Adapter Pattern**: Multi-backend support via uniform adapter interface
+- **Stateless Execution**: No daemon, no caching, ephemeral graph slices per command
+- **Property Graph Model**: WorkItem nodes with typed relation edges
+- **Context-Based Scoping**: Explicit backend selection with isolated credentials
+- **Local-fs Reference**: Filesystem-backed implementation as semantic reference
 
 ## Development Environment
-[Required tools, versions, and setup instructions]
+- **Node.js**: Latest LTS version
+- **TypeScript**: Strict mode with path mapping
+- **CLI Framework**: oclif for command parsing, flag handling, help & completion
+- **Development Tools**: Makefile for unified commands, pre-commit hooks
+- **Testing Framework**: Jest with coverage reporting >80%
+- **Documentation**: TypeDoc generation, built-in CLI help with oclif
 
 ## Code Standards
-[Coding conventions, style guides, and best practices]
+- **TypeScript**: Strict mode, explicit types, no any
+- **Formatting**: Prettier with consistent configuration
+- **Naming**: camelCase for variables/functions, PascalCase for classes
+- **Documentation**: JSDoc comments for public APIs
+- **Error Handling**: Explicit error types, no silent failures
 
 ## Testing Strategy
-[Testing approaches, frameworks, and coverage requirements]
+- **Testing Pyramid**: 70% unit tests, 20% integration tests, 10% end-to-end tests
+- **Unit Tests**: Core logic, adapters, query evaluation with mocking
+- **Integration Tests**: Adapter-backend interactions, context resolution
+- **E2E Tests**: Full CLI workflows, cross-feature scenarios
+- **Performance Tests**: Response time validation for NFR compliance
 
 ## Deployment Process
-[How code gets from development to production]
+- **Build**: TypeScript compilation with bundling
+- **Testing**: Automated test suite with coverage requirements
+- **Release**: Semantic versioning with automated GitHub releases
+- **Distribution**: npm package with cross-platform support
+- **CI/CD**: GitHub Actions with quality gates
 
 ## Performance Requirements
-[Speed, scalability, and resource constraints]
+- **List Operations**: < 2s for up to 1,000 items
+- **CLI Startup**: < 500ms for immediate productivity
+- **Memory Usage**: < 100MB per command execution
+- **Graph Slices**: < 10MB for typical queries
 
 ## Security Considerations
-[Security practices, authentication, and data protection]
+- **Credential Isolation**: Per-context authentication with secure storage
+- **Input Validation**: Sanitization and validation for all user inputs
+- **API Security**: Proper OAuth 2.0 implementation for remote backends
+- **Data Protection**: No sensitive data in logs or temporary files

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,12 @@ This folder contains comprehensive documentation for the `work` CLI - a unified,
 - Security: credential management, data protection
 - Usability, compatibility, and maintainability standards
 
-### [work-poc.md](work-poc.md)
+### [work-cli-tech-selection.md](work-cli-tech-selection.md)
+**CLI technology selection and rationale**
+- Records the technology choice for the CLI layer (oclif framework)
+- Explains rationale for TypeScript/Node.js selection
+- Documents alternatives considered and future TUI considerations
+- Defines CLI layer scope and explicit non-goals
 **Proof of concept implementation plan**
 - Phase 1: Project scaffolding with modern TypeScript development workflow
 - Phase 2: MVP implementation with complete local-fs adapter

--- a/docs/work-cli-tech-selection.md
+++ b/docs/work-cli-tech-selection.md
@@ -1,0 +1,104 @@
+
+# CLI Technology Selection — `work`
+
+This document records the **technology choice for the `work` CLI layer** and the rationale behind it.
+It is intended as a lightweight, durable reference.
+
+---
+
+## Scope
+
+This decision applies **only to the command-line interface layer**:
+- command parsing
+- flag handling
+- help & completion
+- command dispatch
+
+It does **not** apply to:
+- core domain logic
+- adapters
+- data model
+- persistence
+- TUI (future work)
+
+---
+
+## Selected Technology
+
+### CLI Framework: **oclif**
+
+- **Language:** TypeScript / Node.js
+- **Status:** Actively maintained
+- **Adoption:** Widely used for large, long-lived CLIs
+
+`oclif` is the primary and mandatory framework for the `work` CLI.
+
+---
+
+## Rationale
+
+oclif was selected because it:
+
+- is the most widely accepted framework for serious TypeScript CLIs
+- scales well with many commands and subcommands
+- provides strong conventions without hiding control flow
+- supports shell completions and rich help generation
+- keeps CLI concerns separate from core logic
+
+The guiding principle is:
+
+> The CLI parses intent; the core implements semantics.
+
+---
+
+## Explicit Non-Goals
+
+The CLI layer must not contain:
+
+- business logic
+- query evaluation
+- graph construction
+- adapter behavior
+- caching or background processes
+
+It remains a **thin orchestration layer**.
+
+---
+
+## TUI Consideration (Future Work)
+
+- **TUI framework:** OpenTUI
+- **Status:** Not implemented
+- **Command:** `work ui` is reserved
+
+OpenTUI may be introduced later for interactive exploration, but it must not:
+
+- affect CLI semantics
+- introduce a daemon
+- require persistent runtime state
+
+---
+
+## Alternatives Considered
+
+| Option | Reason Not Selected |
+|------|---------------------|
+| Commander.js | Less structure for large CLIs |
+| Yargs | Heavier API, less opinionated |
+| Custom parser | Reinvents solved problems |
+| Vorpal / Gluegun | Lower modern adoption |
+
+---
+
+## Consequences
+
+- Commands are isolated and testable
+- Core logic is framework-agnostic
+- Future UI work is non-breaking
+- The CLI remains scriptable and deterministic
+
+---
+
+## Summary
+
+> **oclif** provides a stable, community-standard foundation for the `work` CLI while keeping all domain semantics outside the CLI layer.


### PR DESCRIPTION
## Problem
The Kiro CLI steering documents contained only skeleton templates with placeholder text, providing no context about the work CLI project for AI-assisted development.

## Solution
Extracted comprehensive project information from the existing documentation in the docs/ folder and populated all steering documents with detailed specifications:

- **Product vision**: Unified task management across multiple backends
- **Technical architecture**: TypeScript/Node.js with oclif and adapter pattern  
- **Project structure**: Complete directory layout and documentation references

## Changes
- **product.md**: Added purpose, target users, key features, and success criteria
- **tech.md**: Specified TypeScript/Node.js stack with oclif CLI framework details
- **structure.md**: Complete directory layout and all documentation file references
- **docs/README.md**: Added work-cli-tech-selection.md reference

## Testing
Verified all steering documents now contain comprehensive project details that align with the existing documentation and provide rich context for development work.

## Example Output
The steering documents now provide detailed context like:
- Target users: "Developers and teams who work across multiple projects using different project management tools"
- Architecture: "Adapter pattern with stateless execution and ephemeral graph slices"
- Performance targets: "< 2s for list operations with up to 1,000 items"

## Notes
This transforms the generic Kiro CLI templates into project-specific documentation that enables much better AI assistance and provides clear project vision for the unified work item CLI development.