### PR TITLE
Docs: Add OSLC CM vocabulary alignment documentation

### DIFF
--- a/.kiro/steering/architecture.md
+++ b/.kiro/steering/architecture.md
@@ -22,6 +22,7 @@ The work CLI is built on three foundational principles that ensure scalability, 
 - **Typed Relations**: Explicit edges (parent_of, blocks, duplicates, relates_to)
 - **Graph Invariants**: Cycle detection, relation validation, consistency enforcement
 - **Tool-Agnostic**: Same mental model works across all supported backends
+- **Standards Alignment**: Core concepts align with [OSLC CM vocabulary](https://docs.oasis-open.org/oslc-domains/cm/v3.0/cm-v3.0.html) while exceeding it with graph-based relationships
 
 ## Context-Based Scoping
 - **Explicit Selection**: No implicit tool guessing or global configuration

--- a/docs/work-graph-ontology-and-runtime.md
+++ b/docs/work-graph-ontology-and-runtime.md
@@ -24,6 +24,8 @@ At its core, `work` models task management as a **property graph**:
 
 This ontology is deliberately small and stable.
 
+**Standards Alignment**: `work` aligns its core concepts with [OSLC CM vocabulary](https://docs.oasis-open.org/oslc-domains/cm/v3.0/cm-v3.0.html) where possible, while deliberately exceeding it with a graph-based internal model that supports explicit relationships and cross-tool workflows.
+
 ---
 
 ### 1.2 Node: `WorkItem`


### PR DESCRIPTION
## Problem
The work CLI's alignment with OSLC CM (Open Services for Lifecycle Collaboration - Change Management) vocabulary was not documented, making it unclear how the system relates to established standards for task management interoperability.

## Solution
Add explicit documentation of OSLC CM alignment in two strategic locations:
- Primary technical detail in the graph ontology document
- High-level architectural principle in the steering documentation

## Changes
- Modified `docs/work-graph-ontology-and-runtime.md` - Added standards alignment statement in ontology overview
- Updated `.kiro/steering/architecture.md` - Added OSLC CM reference to Property Graph Data Model section
- Linked to official OSLC CM v3.0 specification for reference

## Testing
Verified documentation renders correctly and links are functional.

## Example Output
The documentation now clearly states:

> `work` aligns its core concepts with OSLC CM vocabulary where possible, while deliberately exceeding it with a graph-based internal model that supports explicit relationships and cross-tool workflows.

## Notes
This establishes work's commitment to standards compliance while highlighting its enhanced capabilities. The placement ensures both implementers (ontology doc) and architects (steering doc) understand this design principle.