### PR TITLE
Fix: CI workflow step order - build before tests (#14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,11 @@ jobs:
     - name: Run linting
       run: npm run lint
       
-    - name: Run tests
-      run: npm test -- --coverage
-      
     - name: Build project
       run: npm run build
+      
+    - name: Run tests
+      run: npm test -- --coverage
       
     - name: Upload coverage to Codecov
       if: matrix.node-version == '20.x'


### PR DESCRIPTION
## Summary

CI tests were failing with 'command create:Test Task not found' because oclif requires compiled JavaScript files in dist/cli/commands to discover commands, but tests ran before build.

## Root Cause

The CI workflow runs tests before building the TypeScript files, but oclif requires compiled JavaScript files in `dist/cli/commands` to discover and load commands.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Move build step before tests in CI workflow |

## Testing

- [x] Type check passes
- [x] Unit tests pass (48/48)
- [x] Lint passes
- [x] Build completes successfully

## Validation

```bash
npm ci && npm run type-check && npm run lint && npm run build && npm test -- --coverage
```

## Issue

Fixes #14

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

`.claude/PRPs/issues/pr-14.md`

### Deviations from plan:

None - implementation matches artifact exactly

</details>

---

_Automated implementation from investigation artifact_