### PR TITLE
Enforce validation gates and declare architecture invariants in PRP prompts

### DIFF
--- a/.kiro/prompts/prp-implement-ctx7.md
+++ b/.kiro/prompts/prp-implement-ctx7.md
@@ -17,6 +17,10 @@ Execute the plan end-to-end with rigorous self-validation and real-time verifica
 
 **Golden Rule**: If a validation fails, fix it before moving on. Never accumulate broken state. Always prioritize current documentation over plan assumptions when conflicts arise.
 
+**Validation Gate Lock**: If any planned validation command fails, STOP immediately, mark the phase FAILED, and remediate only that gate until it passes with exit code 0.
+
+**Stagnation & Strategy Shift Rule**: If the same class of fix is attempted more than twice without meeting the target, pause to diagnose the failing metric (statements/branches/functions/lines) and explicitly choose a new strategy.
+
 ---
 
 ## Phase 0: DETECT - Project Environment

--- a/.kiro/prompts/prp-plan-ctx7.md
+++ b/.kiro/prompts/prp-plan-ctx7.md
@@ -334,6 +334,8 @@ Use web search to verify:
 
 **DECIDE and document:**
 
+**DECLARE architecture invariants (persistent vs ephemeral state, entities surviving across invocations, idempotent operations) and reference them in tests and acceptance criteria.**
+
 ```markdown
 APPROACH_CHOSEN: [description]
 RATIONALE: [why this over alternatives - reference codebase patterns and current best practices]


### PR DESCRIPTION
### Motivation
- Prevent agents from bypassing validation, drifting intent, or assuming persistence by making validation and architecture guarantees explicit and non-bypassable in planning and implementation prompts.

### Description
- Add an explicit architecture invariant declaration to the planning prompt in `.kiro/prompts/prp-plan-ctx7.md` so plans must state what is persistent vs ephemeral and which operations are idempotent.
- Add a `Validation Gate Lock` and a `Stagnation & Strategy Shift Rule` to the implementation prompt in `.kiro/prompts/prp-implement-ctx7.md` to require immediate stop-and-remediate on failed validations and to force diagnosis/strategy change after repeated failed fix attempts.

### Testing
- Automated tests were not run because these are prompt-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697126de845083329b8a0c338e7fd498)