### PR TITLE
Add CI run requirement to agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ All other files must be organized into appropriate subdirectories.
 - Maintain >80% test coverage
 - Mock external dependencies in unit tests
 - Test files: `*.test.ts` or `*.spec.ts`
+- Hard rule: after a coding session, before reporting back to the user run `make ci` to test the changes and fix issues until the test suite passes.
 
 ### Security Practices
 - Validate and sanitize all user inputs


### PR DESCRIPTION
### Motivation
- Ensure agents validate their changes locally by running the project's CI before reporting back so regressions are caught early.

### Description
- Add a hard rule to `AGENTS.md` under Testing Requirements requiring running `make ci` after a coding session and fixing issues until the test suite passes.

### Testing
- Ran `make ci` (which runs `npm install`, `npm run lint`, `npm run build`, and `npm test -- --coverage`) and confirmed all test suites passed (38 suites, 146 tests) and the CI pipeline completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697143147ab48332b49bab67dca1440d)